### PR TITLE
Add conversation transcript generation

### DIFF
--- a/app/helpers/call_events.py
+++ b/app/helpers/call_events.py
@@ -611,6 +611,13 @@ async def on_end_call(
         ),
     )
 
+    # Store full conversation transcript
+    async with _db.call_transac(
+        call=call,
+        scheduler=scheduler,
+    ):
+        call.transcript = call.generate_transcript()
+
 
 async def _intelligence_sms(
     call: CallStateModel,

--- a/app/models/call.py
+++ b/app/models/call.py
@@ -43,6 +43,7 @@ class CallGetModel(BaseModel):
     next: NextModel | None = None
     reminders: list[ReminderModel] = []
     synthesis: SynthesisModel | None = None
+    transcript: list[dict[str, str]] = Field(default_factory=list)
 
     @field_validator("claim")
     @classmethod
@@ -183,3 +184,13 @@ class CallStateModel(CallGetModel, extra="ignore"):
             and self.messages[-2].persona == MessagePersonaEnum.ASSISTANT
             and self.messages[-1].action == MessageActionEnum.HANGUP
         )
+
+    def generate_transcript(self) -> list[dict[str, str]]:
+        """Return the conversation transcript as a JSON serializable object."""
+        return [
+            {
+                "persona": message.persona.value,
+                "content": message.content,
+            }
+            for message in self.messages
+        ]


### PR DESCRIPTION
## Summary
- add transcript field to `CallGetModel`
- implement `generate_transcript` helper
- store transcript on call end

## Testing
- `make test-static` *(fails: failed to download python-build-standalone)*
- `make test-unit` *(fails: failed to download python-build-standalone)*

------
https://chatgpt.com/codex/tasks/task_e_6887803216648328846d53b3bd70ca2d